### PR TITLE
update to quickcheck-2.6

### DIFF
--- a/ShowQ.hs
+++ b/ShowQ.hs
@@ -26,10 +26,10 @@ tests prop ntest stamps =
        NoExpectedFailure _ _ _ -> done "Arguments exhausted after" (numTests result) stamps
        GaveUp _ _ _ -> done "Arguments exhausted after" (numTests result) stamps
        Success _ _ _  -> done "OK, passed" (numTests result) stamps
-       Failure _ _ _ _ _ _ _ -> return $ "Falsifiable, after "
-                                ++ show ntest
-                                ++ " tests:\n"
-                                ++ reason result
+       Failure _ _ _ _ _ _ _ _ -> return $ "Falsifiable, after "
+                                  ++ show ntest
+                                  ++ " tests:\n"
+                                  ++ reason result
 
 done :: String -> Int -> [[String]] -> IO String
 done mesg ntest stamps = return $ mesg ++ " " ++ show ntest ++ " tests" ++ table

--- a/show.cabal
+++ b/show.cabal
@@ -30,7 +30,7 @@ Flag base4
 library
    exposed-modules:     ShowQ, ShowFun
 
-   build-depends:       random, QuickCheck>=2.4, smallcheck>=1.0
+   build-depends:       random, QuickCheck>=2.6, smallcheck>=1.0
    if flag(base4)
     build-depends:       base == 4.*, syb
    else


### PR DESCRIPTION
Either this, or you have to pin quickcheck to <2.6. Or maybe use #if to check the version?
THey changed the number of arguments to Failure in 2.6
