### PR TITLE
Fix Cabal warning about ghc-prof-options

### DIFF
--- a/show.cabal
+++ b/show.cabal
@@ -32,4 +32,4 @@ library
     build-depends:       base<4
 
    ghc-options:         -Wall
-   ghc-prof-options:    -prof -auto-all
+   ghc-prof-options:    -fprof-auto


### PR DESCRIPTION
```
Warning: 'ghc-prof-options: -prof' is not necessary and will lead to problems
when used on a library. Use the configure flag --enable-library-profiling
and/or --enable-profiling.
```